### PR TITLE
Added bcrypt method which accepts salt as an argument

### DIFF
--- a/src/main/scala/com/github/t3hnar/package.scala
+++ b/src/main/scala/com/github/t3hnar/package.scala
@@ -12,6 +12,8 @@ package object bcrypt {
 
     def bcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
 
+    def bcrypt(salt: String) = B.hashpw(pswrd, salt)
+
     def isBcryptedWithCache(hash: String)(implicit cache: PasswordCache): Boolean = {
       val entry = PasswordCache.CacheEntry(pswrd, hash)
       cache.get(entry) match {


### PR DESCRIPTION
There are cases when I need to know a salt, which may be generated with bcrypt or to be something else. So I've added a method which accepts a salt as an argument
