### PR TITLE
Indicate there is a possibility for bcrypt and isBcrypted to fail in certain situations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.0
-  - 2.11.8
+  - 2.12.2
+  - 2.11.11
   - 2.10.6
 jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Scala Bcrypt is a scala friendly wrapper of [jBCRYPT](http://www.mindrot.org/pro
 
 ```scala
     scala>  "password".isBcrypted("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
-    res2: Boolean = true
+    res2: Try[Boolean] = Success(true)
 ```
 
 #### Advanced usage
@@ -31,7 +31,7 @@ But if you decide that you need to manage salt, you can use `bcrypt` in the foll
     salt: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwO
 
     scala>  "password".bcrypt(salt)
-    res3: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu
+    res3: Try[String] = Success($2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu)
 ```
 
 ## Setup

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "com.github.t3hnar"
 
 description := "Scala wrapper for jBcrypt + pom.xml inside"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.12.0", "2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.12.0", "2.11.11", "2.10.6")
 
 licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0")))
 
@@ -28,7 +28,7 @@ scalacOptions := Seq(
 
 libraryDependencies ++= Seq(
   "de.svenkubiak" % "jBCrypt" % "0.4.1",
-  "org.scalatest" %% "scalatest" % "3.0.0" % Test)
+  "org.scalatest" %% "scalatest" % "3.0.3" % Test)
 
 pomExtra in Global := {
   <scm>

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "Scala wrapper for jBcrypt + pom.xml inside"
 
 scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.12.0", "2.11.11", "2.10.6")
+crossScalaVersions := Seq("2.12.2", "2.11.11", "2.10.6")
 
 licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0")))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.15

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -12,11 +12,17 @@ package object bcrypt {
   implicit class Password(val pswrd: String) extends AnyVal {
     def bcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    def bcrypt(rounds: Int): Try[String] = Try(B.hashpw(pswrd, BCrypt.gensalt(rounds)))
+    def bcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
 
-    def bcrypt(salt: String): Try[String] = Try(B.hashpw(pswrd, salt))
+    def bcrypt(salt: String): String = B.hashpw(pswrd, salt)
 
-    def isBcrypted(hash: String): Try[Boolean] = Try(B.checkpw(pswrd, hash))
+    def isBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
+
+    def bcryptSafe(rounds: Int): Try[String] = Try(B.hashpw(pswrd, BCrypt.gensalt(rounds)))
+
+    def bcryptSafe(salt: String): Try[String] = Try(B.hashpw(pswrd, salt))
+
+    def isBcryptedSafe(hash: String): Try[Boolean] = Try(B.checkpw(pswrd, hash))
   }
 
   def generateSalt: String = B.gensalt()

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -2,6 +2,8 @@ package com.github.t3hnar
 
 import org.mindrot.jbcrypt.{BCrypt => B}
 
+import scala.util.Try
+
 /**
  * @author Yaroslav Klymko
  */
@@ -10,11 +12,11 @@ package object bcrypt {
   implicit class Password(val pswrd: String) extends AnyVal {
     def bcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    def bcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
+    def bcrypt(rounds: Int): Try[String] = Try(B.hashpw(pswrd, BCrypt.gensalt(rounds)))
 
-    def bcrypt(salt: String): String = B.hashpw(pswrd, salt)
+    def bcrypt(salt: String): Try[String] = Try(B.hashpw(pswrd, salt))
 
-    def isBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
+    def isBcrypted(hash: String): Try[Boolean] = Try(B.checkpw(pswrd, hash))
   }
 
   def generateSalt: String = B.gensalt()

--- a/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
+++ b/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
@@ -4,38 +4,59 @@ import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Success
 
-
 class bcryptSpec extends WordSpec with Matchers {
-
-  "bcrypt" should {
+  "safe APIs" should {
     "encrypt and check if bcrypted" in {
       val hash = "my password".bcrypt
-      "my password".isBcrypted(hash) shouldEqual Success(true)
-      "my new password".isBcrypted(hash) shouldEqual Success(false)
+      "my password".isBcryptedSafe(hash) shouldEqual Success(true)
+      "my new password".isBcryptedSafe(hash) shouldEqual Success(false)
+    }
+
+    "encrypt with provided salt and check if bcrypted" in {
+      val salt = BCrypt.gensalt()
+      val hash = "password".bcryptSafe(salt)
+      hash.isSuccess shouldEqual true
+      val extractedHash = hash.get
+      "password".isBcryptedSafe(extractedHash) shouldEqual Success(true)
+      "my new password".isBcryptedSafe(extractedHash) shouldEqual Success(false)
+    }
+
+    "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
+      val result = "password".isBcryptedSafe("password")
+      result.isFailure shouldEqual true
+    }
+
+    "attempting to use rounds > 30 will result in a scala.util.Failure" in {
+      val result = "password".bcryptSafe(31)
+      result.isFailure shouldEqual true
+    }
+
+    "attempting to use an invalid salt will result in a scala.util.Failure" in {
+      val result = "password".bcryptSafe("invalid-salt")
+      result.isFailure shouldEqual true
+    }
+  }
+
+  "unsafe APIs" should {
+    "encrypt and check if bcrypted" in {
+      val hash = "my password".bcrypt
+      "my password".isBcrypted(hash) shouldEqual true
+      "my new password".isBcrypted(hash) shouldEqual false
     }
 
     "encrypt with provided salt and check if bcrypted" in {
       val salt = BCrypt.gensalt()
       val hash = "password".bcrypt(salt)
-      hash.isSuccess shouldEqual true
-      val extractedHash = hash.get
-      "password".isBcrypted(extractedHash) shouldEqual Success(true)
-      "my new password".isBcrypted(extractedHash) shouldEqual Success(false)
+      "password".isBcrypted(hash) shouldEqual true
+      "my new password".isBcrypted(hash) shouldEqual false
     }
 
-    "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
-      val result = "password".isBcrypted("password")
-      result.isFailure shouldEqual true
-    }
-
-    "attempting to use rounds > 30 will result in a scala.util.Failure" in {
-      val result = "password".bcrypt(31)
-      result.isFailure shouldEqual true
-    }
-
-    "attempting to use an invalid salt will result in a scala.util.Failure" in {
-      val result = "password".bcrypt("invalid-salt")
-      result.isFailure shouldEqual true
+    "throw an exception if bcrypt parameters are incorrect" in {
+      val invalidSalt = "bad-salt"
+      val caught = intercept[IllegalArgumentException] {
+        "password".bcrypt(invalidSalt)
+      }
+      caught.getMessage shouldEqual "Invalid salt version"
     }
   }
 }

--- a/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
+++ b/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
@@ -2,21 +2,40 @@ package com.github.t3hnar.bcrypt
 
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.Success
+
 
 class bcryptSpec extends WordSpec with Matchers {
 
   "bcrypt" should {
     "encrypt and check if bcrypted" in {
       val hash = "my password".bcrypt
-      "my password".isBcrypted(hash) shouldEqual true
-      "my new password".isBcrypted(hash) shouldEqual false
+      "my password".isBcrypted(hash) shouldEqual Success(true)
+      "my new password".isBcrypted(hash) shouldEqual Success(false)
     }
 
     "encrypt with provided salt and check if bcrypted" in {
       val salt = BCrypt.gensalt()
       val hash = "password".bcrypt(salt)
-      "password".isBcrypted(hash) shouldEqual true
-      "my new password".isBcrypted(hash) shouldEqual false
+      hash.isSuccess shouldEqual true
+      val extractedHash = hash.get
+      "password".isBcrypted(extractedHash) shouldEqual Success(true)
+      "my new password".isBcrypted(extractedHash) shouldEqual Success(false)
+    }
+
+    "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
+      val result = "password".isBcrypted("password")
+      result.isFailure shouldEqual true
+    }
+
+    "attempting to use rounds > 30 will result in a scala.util.Failure" in {
+      val result = "password".bcrypt(31)
+      result.isFailure shouldEqual true
+    }
+
+    "attempting to use an invalid salt will result in a scala.util.Failure" in {
+      val result = "password".bcrypt("invalid-salt")
+      result.isFailure shouldEqual true
     }
   }
 }


### PR DESCRIPTION
Hey there, 

Thanks for making this library, we use it and find it very convenient. We encountered some exceptions when we were using it and hoped to improve the API to convey that certain operations may fail. These are API breaking changes but they convey the possibility of exceptions more explicitly although you would now have to resort to monadic composition to compose dependent operations

```scala
val bcryptAndVerify = for {
  bcrypted <- "hello".bcrypt(12)
  result <- "hello".isBcrypted(bcrypted)
} yield result
// Success(true)
```

Cheers and Thanks
Cal