### PR TITLE
cross compile for scala 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "Scala wrapper for jBcrypt + pom.xml inside"
 
 scalaVersion := crossScalaVersions.value.last
 
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
 
 releaseCrossBuild := true
 
@@ -23,14 +23,12 @@ scalacOptions := Seq(
   "-deprecation",
   "-Xfatal-warnings",
   "-Xlint",
-  "-Yno-adapted-args",
   "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-Xfuture")
+  "-Ywarn-numeric-widen")
 
 libraryDependencies ++= Seq(
   "de.svenkubiak" % "jBCrypt" % "0.4.1",
-  "org.scalatest" %% "scalatest" % "3.0.6" % Test)
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test)
 
 pomExtra in Global := {
   <scm>


### PR DESCRIPTION
Cross compile for 2.13.0. Removed -xfuture as is removed from 2.13

```bash
[error] -Xfuture is deprecated: Not used since 2.13.
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 1 s, completed Jun 12, 2019, 11:10:25 AM
```

tests
-----

```bash
λ sbt test
[info] Loading settings for project global-plugins from idea.sbt,credentials.sbt,metals.sbt ...
[info] Loading global plugins from /Users/a1353612/.sbt/1.0/plugins
[info] Loading settings for project scala-bcrypt-build from plugins.sbt ...
[info] Loading project definition from /Users/a1353612/soundofmusic/compile1010/scala-bcrypt/project
[info] Loading settings for project scala-bcrypt from version.sbt,build.sbt ...
[info] Set current project to scala-bcrypt (in build file:/Users/a1353612/soundofmusic/compile1010/scala-bcrypt/)
[info] bcryptSpec:
[info] safe APIs
[info] - should encrypt and check if bcrypted
[info] - should encrypt with provided salt and check if bcrypted
[info] - should attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure
[info] - should attempting to use rounds > 30 will result in a scala.util.Failure
[info] - should attempting to use an invalid salt will result in a scala.util.Failure
[info] unsafe APIs
[info] - should encrypt and check if bcrypted
[info] - should encrypt with provided salt and check if bcrypted
[info] - should throw an exception if bcrypt parameters are incorrect
[info] Run completed in 1 second, 316 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 3 s, completed Jun 12, 2019, 11:13:35 AM
```