### PR TITLE
Added bounded API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ rounds (eg. > 30 rounds).
     scala>  import com.github.t3hnar.bcrypt._
     import com.github.t3hnar.bcrypt._
 
-    scala>  "password".boundedBcryptSafe
+    scala>  "password".bcryptSafeBounded
     res1: Try[String] = Success($2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG)
 ```
 
 #### Validate password
 
 ```scala
-    scala>  "password".isBoundedBcryptedSafe("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
+    scala>  "password".isBcryptedSafeBounded("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
     res2: Try[Boolean] = Success(true)
 ```
 
@@ -31,8 +31,8 @@ Since `Try` is monadic, you can use a for-comprehension to compose operations th
 fail-fast semantics. You can also use the desugared notation (`flatMap`s and `map`s) if you prefer.
 ```scala
     scala>  val bcryptAndVerify = for {
-      bcrypted <- "hello".boundedBcrypt(12)
-      result <- "hello".isBoundedBcryptedSafe(bcrypted)
+      bcrypted <- "hello".bcryptBounded(12)
+      result <- "hello".isBcryptedSafeBounded(bcrypted)
     } yield result
     res: Try[Boolean] = Success(true)
 ```
@@ -46,7 +46,7 @@ But if you decide that you need to manage salt, you can use `bcrypt` in the foll
     scala>  val salt = generateSalt
     salt: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwO
 
-    scala>  "password".boundedBcrypt(salt)
+    scala>  "password".bcryptBounded(salt)
     res3: Try[String] = Success($2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu)
 ```
 
@@ -61,14 +61,14 @@ backwards compatibility reasons and should be avoided if possible.
     scala>  import com.github.t3hnar.bcrypt._
     import com.github.t3hnar.bcrypt._
 
-    scala>  "password".boundedBcrypt
+    scala>  "password".bcryptBounded
     res1: String = $2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG
 ```
 
 #### Validate password
 
 ```scala
-    scala>  "password".isBoundedBcrypted("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
+    scala>  "password".isBcryptedBounded("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
     res2: Boolean = true
 ```
 
@@ -78,7 +78,7 @@ backwards compatibility reasons and should be avoided if possible.
     scala>  val salt = generateSalt
     salt: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwO
 
-    scala>  "password".boundedBcrypt(salt)
+    scala>  "password".bcryptBounded(salt)
     res3: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,24 +15,24 @@ rounds (eg. > 30 rounds).
     scala>  import com.github.t3hnar.bcrypt._
     import com.github.t3hnar.bcrypt._
 
-    scala>  "password".bcrypt
-    res1: String = $2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG
+    scala>  "password".boundedBcryptSafe
+    res1: Try[String] = Success($2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG)
 ```
 
 #### Validate password
 
 ```scala
-    scala>  "password".isBcryptedSafe("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
+    scala>  "password".isBoundedBcryptedSafe("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
     res2: Try[Boolean] = Success(true)
 ```
 
 #### Composition
 Since `Try` is monadic, you can use a for-comprehension to compose operations that return `Success` or `Failure` with
-fail-fast semantics. You can also use the desugared notation (`flatMap`s and `map`s) if you prefer
+fail-fast semantics. You can also use the desugared notation (`flatMap`s and `map`s) if you prefer.
 ```scala
     scala>  val bcryptAndVerify = for {
-      bcrypted <- "hello".bcrypt(12)
-      result <- "hello".isBcryptedSafe(bcrypted)
+      bcrypted <- "hello".safeBoundedBcrypt(12)
+      result <- "hello".isBoundedBcryptedSafe(bcrypted)
     } yield result
     res: Try[Boolean] = Success(true)
 ```
@@ -46,14 +46,14 @@ But if you decide that you need to manage salt, you can use `bcrypt` in the foll
     scala>  val salt = generateSalt
     salt: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwO
 
-    scala>  "password".bcrypt(salt)
+    scala>  "password".boundedBcrypt(salt)
     res3: Try[String] = Success($2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu)
 ```
 
 ### Unsafe APIs
 The Unsafe APIs will result in Exceptions being thrown when executing operations as certain bcrypt operations can fail 
-due to providing incorrect salt versions or number of rounds (eg. > 30 rounds). These Unsafe APIs are present for 
-backwards compatibility reasons and should be avoided if possible
+due to providing incorrect salt versions or number of rounds (eg. > 30 rounds or password longer than 71 bytes). These Unsafe APIs are present for 
+backwards compatibility reasons and should be avoided if possible.
 
 #### Encrypt password
 
@@ -61,14 +61,14 @@ backwards compatibility reasons and should be avoided if possible
     scala>  import com.github.t3hnar.bcrypt._
     import com.github.t3hnar.bcrypt._
 
-    scala>  "password".bcrypt
+    scala>  "password".boundedBcrypt
     res1: String = $2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG
 ```
 
 #### Validate password
 
 ```scala
-    scala>  "password".isBcrypted("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
+    scala>  "password".isBoundedBcrypted("$2a$10$iXIfki6AefgcUsPqR.niQ.FvIK8vdcfup09YmUxmzS/sQeuI3QOFG")
     res2: Boolean = true
 ```
 
@@ -78,7 +78,7 @@ backwards compatibility reasons and should be avoided if possible
     scala>  val salt = generateSalt
     salt: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwO
 
-    scala>  "password".bcrypt(salt)
+    scala>  "password".boundedBcrypt(salt)
     res3: String = $2a$10$8K1p/a0dL1LXMIgoEDFrwOfMQbLgtnOoKsWc.6U6H0llP3puzeeEu
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Since `Try` is monadic, you can use a for-comprehension to compose operations th
 fail-fast semantics. You can also use the desugared notation (`flatMap`s and `map`s) if you prefer.
 ```scala
     scala>  val bcryptAndVerify = for {
-      bcrypted <- "hello".safeBoundedBcrypt(12)
+      bcrypted <- "hello".boundedBcrypt(12)
       result <- "hello".isBoundedBcryptedSafe(bcrypted)
     } yield result
     res: Try[Boolean] = Success(true)

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ scalacOptions := Seq(
   "-encoding", "UTF-8",
   "-feature",
   "-unchecked",
+  "-deprecation",
+  "-Xlint",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen")
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,6 @@ scalacOptions := Seq(
   "-encoding", "UTF-8",
   "-feature",
   "-unchecked",
-  "-deprecation",
-  "-Xfatal-warnings",
-  "-Xlint",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen")
 

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -2,27 +2,133 @@ package com.github.t3hnar
 
 import org.mindrot.jbcrypt.{BCrypt => B}
 
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 /**
  * @author Yaroslav Klymko
  */
 package object bcrypt {
 
+  private val maxLength = 71 // max tested bytes that the library can handle before it stops working
+
+  // Maybe consider moving the non deprecated methods no another package with the same method names (loose the "bounded")
+  // This way the only change the developers would need to make is change the package
   implicit class BCryptStrOps(val pswrd: String) extends AnyVal {
-    def bcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    def bcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
+    @Deprecated
+    def bcrypt: String = {
+      warn("bcrypt", "boundedBcrypt")
+      doBcrypt
+    }
 
-    def bcrypt(salt: String): String = B.hashpw(pswrd, salt)
+    def boundedBcrypt: String = {
+      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      else doBcrypt
+    }
 
-    def isBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
+    def safeBoundedBcrypt: Try[String] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      else Try(doBcrypt)
+    }
 
-    def bcryptSafe(rounds: Int): Try[String] = Try(B.hashpw(pswrd, BCrypt.gensalt(rounds)))
+    // The defualt rounds in BCrypt.gensalt() is 10. This may lead to user confusion when using the api.
+    // I suggest adding an explicit 1, or updating the documentation.
+    private def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    def bcryptSafe(salt: String): Try[String] = Try(B.hashpw(pswrd, salt))
+    @Deprecated
+    def bcrypt(rounds: Int): String = {
+      warn("bcrypt", "boundedBcrypt")
+      doBcrypt(rounds)
+    }
 
-    def isBcryptedSafe(hash: String): Try[Boolean] = Try(B.checkpw(pswrd, hash))
+    def boundedBcrypt(rounds: Int): String = {
+      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      else doBcrypt(rounds)
+    }
+
+    def safeBoundedBcrypt(rounds: Int): Try[String] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      else Try(doBcrypt(rounds))
+    }
+
+    private def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
+
+    @Deprecated
+    def bcrypt(salt: String): String = {
+      warn("bcrypt", "boundedBcrypt")
+      doBcrypt(salt)
+    }
+
+    def boundedBcrypt(salt: String): String = {
+      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      else doBcrypt(salt)
+    }
+
+    def safeBoundedBcrypt(salt: String): Try[String] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      else Try(doBcrypt(salt))
+    }
+
+    private def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)
+
+    @Deprecated
+    def isBcrypted(hash: String): Boolean = {
+      warn("isBcrypted", "isBoundedBcrypted")
+      doIsBcrypted(hash)
+    }
+
+    def isBoundedBcrypted(hash: String): Boolean = {
+      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      else doIsBcrypted(hash)
+    }
+
+    private def doIsBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
+
+    @Deprecated
+    def bcryptSafe(rounds: Int): Try[String] = {
+      warn("bcryptSafe", "boundedBcryptSafe")
+      Try(doBcrypt(rounds))
+    }
+
+    def boundedBcryptSafe(rounds: Int): Try[String] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      else Try(doBcrypt(rounds))
+    }
+
+    @Deprecated
+    def bcryptSafe(salt: String): Try[String] = {
+      warn("bcryptSafe", "boundedBcryptSafe")
+      Try(doBcrypt(salt))
+    }
+
+    def boundedBcryptSafe(salt: String): Try[String] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      else Try(doBcrypt(salt))
+    }
+
+    @Deprecated
+    def isBcryptedSafe(hash: String): Try[Boolean] = {
+      warn("isBcryptedSafe", "isBoundedBcryptedSafe")
+      Try(doIsBcrypted(hash))
+    }
+
+    def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {
+      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"pswr was more than $maxLength bytes long."))
+      else Try(doIsBcrypted(hash))
+    }
+
+    private def moreThanLength(length: Int): Boolean = pswrd.length > length
+
+    private def warn(oldMethod: String, newMethod: String): Unit = {
+      val message: String = s"[warn] method $oldMethod is deprecated. Use $newMethod instead.\n" +
+        "To supress this warning, add a DEBUG environment variable to false.\n" +
+        "More information at https://github.com/t3hnar/scala-bcrypt/issues/23"
+      sys.env.get("DEBUG")
+        .map(_ != false)
+        .filter(a => a)
+        .map(_ => println(message))
+        .getOrElse(println(message))
+    }
   }
 
   def generateSalt: String = B.gensalt()

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -13,8 +13,7 @@ package object bcrypt {
   // This way the only change the developers would need to make is change the package
   implicit class BCryptStrOps(val pswrd: String) extends AnyVal {
 
-    @deprecated("Use boundedBcrypt instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def bcrypt: String = doBcrypt
 
     def boundedBcrypt: String = {
@@ -26,8 +25,7 @@ package object bcrypt {
     // I suggest adding an explicit 1, or updating the documentation.
     private[this] def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    @deprecated("Use boundedBcrypt(rounds: Int) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def bcrypt(rounds: Int): String = doBcrypt(rounds)
 
     def boundedBcrypt(rounds: Int): String = {
@@ -42,8 +40,7 @@ package object bcrypt {
 
     private[this] def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
 
-    @deprecated("Use boundedBcrypt(salt: String) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def bcrypt(salt: String): String = doBcrypt(salt)
 
     def boundedBcrypt(salt: String): String = {
@@ -53,8 +50,7 @@ package object bcrypt {
 
     private[this] def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)
 
-    @deprecated("Use isBoundedBcrypted(hash: String) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use isBoundedBcrypted(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def isBcrypted(hash: String): Boolean = doIsBcrypted(hash)
 
     def isBoundedBcrypted(hash: String): Boolean = {
@@ -64,8 +60,7 @@ package object bcrypt {
 
     private[this] def doIsBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
 
-    @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def bcryptSafe(rounds: Int): Try[String] = Try(doBcrypt(rounds))
 
     def boundedBcryptSafe(rounds: Int): Try[String] = {
@@ -73,8 +68,7 @@ package object bcrypt {
       else Try(doBcrypt(rounds))
     }
 
-    @deprecated("Use boundedBcryptSafe(salt: String) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcryptSafe(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def bcryptSafe(salt: String): Try[String] = Try(doBcrypt(salt))
 
     def boundedBcryptSafe(salt: String): Try[String] = {
@@ -82,8 +76,7 @@ package object bcrypt {
       else Try(doBcrypt(salt))
     }
 
-    @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\n" +
-      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
     def isBcryptedSafe(hash: String): Try[Boolean] = Try(doIsBcrypted(hash))
 
     def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -28,12 +28,12 @@ package object bcrypt {
     @deprecated("Use boundedBcrypt(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcrypt(rounds: Int): String = doBcrypt(rounds)
 
-    def boundedBcrypt(rounds: Int): String = {
+    def bcryptBounded(rounds: Int): String = {
       if(moreThanLength()) throw illegalArgumentException
       else doBcrypt(rounds)
     }
 
-    def boundedBcryptSafe: Try[String] = {
+    def bcryptSafeBounded: Try[String] = {
       if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt)
     }
@@ -43,7 +43,7 @@ package object bcrypt {
     @deprecated("Use boundedBcrypt(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcrypt(salt: String): String = doBcrypt(salt)
 
-    def boundedBcrypt(salt: String): String = {
+    def bcryptBounded(salt: String): String = {
       if(moreThanLength()) throw illegalArgumentException
       else doBcrypt(salt)
     }
@@ -53,7 +53,7 @@ package object bcrypt {
     @deprecated("Use isBoundedBcrypted(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def isBcrypted(hash: String): Boolean = doIsBcrypted(hash)
 
-    def isBoundedBcrypted(hash: String): Boolean = {
+    def isBcryptedBounded(hash: String): Boolean = {
       if(moreThanLength()) throw illegalArgumentException
       else doIsBcrypted(hash)
     }
@@ -63,7 +63,7 @@ package object bcrypt {
     @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcryptSafe(rounds: Int): Try[String] = Try(doBcrypt(rounds))
 
-    def boundedBcryptSafe(rounds: Int): Try[String] = {
+    def bcryptSafeBounded(rounds: Int): Try[String] = {
       if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt(rounds))
     }
@@ -71,7 +71,7 @@ package object bcrypt {
     @deprecated("Use boundedBcryptSafe(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcryptSafe(salt: String): Try[String] = Try(doBcrypt(salt))
 
-    def boundedBcryptSafe(salt: String): Try[String] = {
+    def bcryptSafeBounded(salt: String): Try[String] = {
       if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt(salt))
     }
@@ -79,7 +79,7 @@ package object bcrypt {
     @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def isBcryptedSafe(hash: String): Try[Boolean] = Try(doIsBcrypted(hash))
 
-    def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {
+    def isBcryptedSafeBounded(hash: String): Try[Boolean] = {
       if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doIsBcrypted(hash))
     }

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -24,11 +24,6 @@ package object bcrypt {
       else doBcrypt
     }
 
-    def safeBoundedBcrypt: Try[String] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
-      else Try(doBcrypt)
-    }
-
     // The defualt rounds in BCrypt.gensalt() is 10. This may lead to user confusion when using the api.
     // I suggest adding an explicit 1, or updating the documentation.
     private[this] def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
@@ -42,9 +37,9 @@ package object bcrypt {
       else doBcrypt(rounds)
     }
 
-    def safeBoundedBcrypt(rounds: Int): Try[String] = {
+    def boundedBcryptSafe: Try[String] = {
       if(moreThanLength(maxLength)) Failure(illegalArgumentException)
-      else Try(doBcrypt(rounds))
+      else Try(doBcrypt)
     }
 
     private[this] def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
@@ -56,11 +51,6 @@ package object bcrypt {
     def boundedBcrypt(salt: String): String = {
       if(moreThanLength(maxLength)) throw illegalArgumentException
       else doBcrypt(salt)
-    }
-
-    def safeBoundedBcrypt(salt: String): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
-      else Try(doBcrypt(salt))
     }
 
     private[this] def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -13,7 +13,7 @@ package object bcrypt {
   // This way the only change the developers would need to make is change the package
   implicit class BCryptStrOps(val pswrd: String) extends AnyVal {
 
-    @deprecated("Use boundedBcrypt instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcrypt: String = doBcrypt
 
     def boundedBcrypt: String = {
@@ -25,7 +25,7 @@ package object bcrypt {
     // I suggest adding an explicit 1, or updating the documentation.
     private[this] def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    @deprecated("Use boundedBcrypt(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcrypt(rounds: Int): String = doBcrypt(rounds)
 
     def boundedBcrypt(rounds: Int): String = {
@@ -40,7 +40,7 @@ package object bcrypt {
 
     private[this] def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
 
-    @deprecated("Use boundedBcrypt(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcrypt(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcrypt(salt: String): String = doBcrypt(salt)
 
     def boundedBcrypt(salt: String): String = {
@@ -50,7 +50,7 @@ package object bcrypt {
 
     private[this] def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)
 
-    @deprecated("Use isBoundedBcrypted(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use isBoundedBcrypted(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def isBcrypted(hash: String): Boolean = doIsBcrypted(hash)
 
     def isBoundedBcrypted(hash: String): Boolean = {
@@ -60,7 +60,7 @@ package object bcrypt {
 
     private[this] def doIsBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
 
-    @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcryptSafe(rounds: Int): Try[String] = Try(doBcrypt(rounds))
 
     def boundedBcryptSafe(rounds: Int): Try[String] = {
@@ -68,7 +68,7 @@ package object bcrypt {
       else Try(doBcrypt(rounds))
     }
 
-    @deprecated("Use boundedBcryptSafe(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use boundedBcryptSafe(salt: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def bcryptSafe(salt: String): Try[String] = Try(doBcrypt(salt))
 
     def boundedBcryptSafe(salt: String): Try[String] = {
@@ -76,7 +76,7 @@ package object bcrypt {
       else Try(doBcrypt(salt))
     }
 
-    @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\nMore information at https://github.com/t3hnar/scala-bcrypt/issues/23")
     def isBcryptedSafe(hash: String): Try[Boolean] = Try(doIsBcrypted(hash))
 
     def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -9,126 +9,103 @@ import scala.util.{Failure, Try}
  */
 package object bcrypt {
 
-  private val maxLength = 71 // max tested bytes that the library can handle before it stops working
+  private[this] val maxLength = 71 // max tested bytes that the library can handle before it stops working
 
   // Maybe consider moving the non deprecated methods no another package with the same method names (loose the "bounded")
   // This way the only change the developers would need to make is change the package
   implicit class BCryptStrOps(val pswrd: String) extends AnyVal {
 
-    @Deprecated
-    def bcrypt: String = {
-      warn("bcrypt", "boundedBcrypt")
-      doBcrypt
-    }
+    @deprecated("Use boundedBcrypt instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def bcrypt: String = doBcrypt
 
     def boundedBcrypt: String = {
-      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      if(moreThanLength(maxLength)) throw illegalArgumentException
       else doBcrypt
     }
 
     def safeBoundedBcrypt: Try[String] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doBcrypt)
     }
 
     // The defualt rounds in BCrypt.gensalt() is 10. This may lead to user confusion when using the api.
     // I suggest adding an explicit 1, or updating the documentation.
-    private def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
+    private[this] def doBcrypt: String = B.hashpw(pswrd, BCrypt.gensalt())
 
-    @Deprecated
-    def bcrypt(rounds: Int): String = {
-      warn("bcrypt", "boundedBcrypt")
-      doBcrypt(rounds)
-    }
+    @deprecated("Use boundedBcrypt(rounds: Int) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def bcrypt(rounds: Int): String = doBcrypt(rounds)
 
     def boundedBcrypt(rounds: Int): String = {
-      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      if(moreThanLength(maxLength)) throw illegalArgumentException
       else doBcrypt(rounds)
     }
 
     def safeBoundedBcrypt(rounds: Int): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doBcrypt(rounds))
     }
 
-    private def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
+    private[this] def doBcrypt(rounds: Int): String = B.hashpw(pswrd, BCrypt.gensalt(rounds))
 
-    @Deprecated
-    def bcrypt(salt: String): String = {
-      warn("bcrypt", "boundedBcrypt")
-      doBcrypt(salt)
-    }
+    @deprecated("Use boundedBcrypt(salt: String) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def bcrypt(salt: String): String = doBcrypt(salt)
 
     def boundedBcrypt(salt: String): String = {
-      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      if(moreThanLength(maxLength)) throw illegalArgumentException
       else doBcrypt(salt)
     }
 
     def safeBoundedBcrypt(salt: String): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doBcrypt(salt))
     }
 
-    private def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)
+    private[this] def doBcrypt(salt: String): String = B.hashpw(pswrd, salt)
 
-    @Deprecated
-    def isBcrypted(hash: String): Boolean = {
-      warn("isBcrypted", "isBoundedBcrypted")
-      doIsBcrypted(hash)
-    }
+    @deprecated("Use isBoundedBcrypted(hash: String) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def isBcrypted(hash: String): Boolean = doIsBcrypted(hash)
 
     def isBoundedBcrypted(hash: String): Boolean = {
-      if(moreThanLength(maxLength)) throw new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+      if(moreThanLength(maxLength)) throw illegalArgumentException
       else doIsBcrypted(hash)
     }
 
-    private def doIsBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
+    private[this] def doIsBcrypted(hash: String): Boolean = B.checkpw(pswrd, hash)
 
-    @Deprecated
-    def bcryptSafe(rounds: Int): Try[String] = {
-      warn("bcryptSafe", "boundedBcryptSafe")
-      Try(doBcrypt(rounds))
-    }
+    @deprecated("Use boundedBcryptSafe(rounds: Int) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def bcryptSafe(rounds: Int): Try[String] = Try(doBcrypt(rounds))
 
     def boundedBcryptSafe(rounds: Int): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doBcrypt(rounds))
     }
 
-    @Deprecated
-    def bcryptSafe(salt: String): Try[String] = {
-      warn("bcryptSafe", "boundedBcryptSafe")
-      Try(doBcrypt(salt))
-    }
+    @deprecated("Use boundedBcryptSafe(salt: String) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def bcryptSafe(salt: String): Try[String] = Try(doBcrypt(salt))
 
     def boundedBcryptSafe(salt: String): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doBcrypt(salt))
     }
 
-    @Deprecated
-    def isBcryptedSafe(hash: String): Try[Boolean] = {
-      warn("isBcryptedSafe", "isBoundedBcryptedSafe")
-      Try(doIsBcrypted(hash))
-    }
+    @deprecated("Use isBoundedBcryptedSafe(hash: String) instead.\n" +
+      "More information at https://github.com/t3hnar/scala-bcrypt/issues/23", "4.1.1")
+    def isBcryptedSafe(hash: String): Try[Boolean] = Try(doIsBcrypted(hash))
 
     def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {
-      if(moreThanLength(maxLength)) Failure(new IllegalArgumentException(s"pswr was more than $maxLength bytes long."))
+      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
       else Try(doIsBcrypted(hash))
     }
 
-    private def moreThanLength(length: Int): Boolean = pswrd.length > length
+    private[this] def illegalArgumentException = new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
 
-    private def warn(oldMethod: String, newMethod: String): Unit = {
-      val message: String = s"[warn] method $oldMethod is deprecated. Use $newMethod instead.\n" +
-        "To supress this warning, add a DEBUG environment variable to false.\n" +
-        "More information at https://github.com/t3hnar/scala-bcrypt/issues/23"
-      sys.env.get("DEBUG")
-        .map(_ != false)
-        .filter(a => a)
-        .map(_ => println(message))
-        .getOrElse(println(message))
-    }
+    private[this] def moreThanLength(length: Int): Boolean = pswrd.length > length
   }
 
   def generateSalt: String = B.gensalt()

--- a/src/main/scala/com/github/t3hnar/bcrypt/package.scala
+++ b/src/main/scala/com/github/t3hnar/bcrypt/package.scala
@@ -9,8 +9,6 @@ import scala.util.{Failure, Try}
  */
 package object bcrypt {
 
-  private[this] val maxLength = 71 // max tested bytes that the library can handle before it stops working
-
   // Maybe consider moving the non deprecated methods no another package with the same method names (loose the "bounded")
   // This way the only change the developers would need to make is change the package
   implicit class BCryptStrOps(val pswrd: String) extends AnyVal {
@@ -20,7 +18,7 @@ package object bcrypt {
     def bcrypt: String = doBcrypt
 
     def boundedBcrypt: String = {
-      if(moreThanLength(maxLength)) throw illegalArgumentException
+      if(moreThanLength()) throw illegalArgumentException
       else doBcrypt
     }
 
@@ -33,12 +31,12 @@ package object bcrypt {
     def bcrypt(rounds: Int): String = doBcrypt(rounds)
 
     def boundedBcrypt(rounds: Int): String = {
-      if(moreThanLength(maxLength)) throw illegalArgumentException
+      if(moreThanLength()) throw illegalArgumentException
       else doBcrypt(rounds)
     }
 
     def boundedBcryptSafe: Try[String] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
+      if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt)
     }
 
@@ -49,7 +47,7 @@ package object bcrypt {
     def bcrypt(salt: String): String = doBcrypt(salt)
 
     def boundedBcrypt(salt: String): String = {
-      if(moreThanLength(maxLength)) throw illegalArgumentException
+      if(moreThanLength()) throw illegalArgumentException
       else doBcrypt(salt)
     }
 
@@ -60,7 +58,7 @@ package object bcrypt {
     def isBcrypted(hash: String): Boolean = doIsBcrypted(hash)
 
     def isBoundedBcrypted(hash: String): Boolean = {
-      if(moreThanLength(maxLength)) throw illegalArgumentException
+      if(moreThanLength()) throw illegalArgumentException
       else doIsBcrypted(hash)
     }
 
@@ -71,7 +69,7 @@ package object bcrypt {
     def bcryptSafe(rounds: Int): Try[String] = Try(doBcrypt(rounds))
 
     def boundedBcryptSafe(rounds: Int): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
+      if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt(rounds))
     }
 
@@ -80,7 +78,7 @@ package object bcrypt {
     def bcryptSafe(salt: String): Try[String] = Try(doBcrypt(salt))
 
     def boundedBcryptSafe(salt: String): Try[String] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
+      if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doBcrypt(salt))
     }
 
@@ -89,13 +87,13 @@ package object bcrypt {
     def isBcryptedSafe(hash: String): Try[Boolean] = Try(doIsBcrypted(hash))
 
     def isBoundedBcryptedSafe(hash: String): Try[Boolean] = {
-      if(moreThanLength(maxLength)) Failure(illegalArgumentException)
+      if(moreThanLength()) Failure(illegalArgumentException)
       else Try(doIsBcrypted(hash))
     }
 
-    private[this] def illegalArgumentException = new IllegalArgumentException(s"$pswrd was more than $maxLength bytes long.")
+    private[this] def illegalArgumentException = new IllegalArgumentException(s"$pswrd was more than 71 bytes long.")
 
-    private[this] def moreThanLength(length: Int): Boolean = pswrd.length > length
+    private[this] def moreThanLength(length: Int = 71): Boolean = pswrd.length > length
   }
 
   def generateSalt: String = B.gensalt()

--- a/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
+++ b/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
@@ -9,53 +9,53 @@ class bcryptSpec extends WordSpec with Matchers {
     "bounded APIs" should {
       "encrypt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
         val password = "my password"
-        val tryHash = password.boundedBcryptSafe
+        val tryHash = password.bcryptSafeBounded
         tryHash.map { hash =>
-          password.isBoundedBcryptedSafe(hash) shouldEqual Success(true)
-          "my new password".isBoundedBcryptedSafe(hash) shouldEqual Success(false)
+          password.isBcryptedSafeBounded(hash) shouldEqual Success(true)
+          "my new password".isBcryptedSafeBounded(hash) shouldEqual Success(false)
         }.getOrElse(fail("failed while trying to bcrypt"))
         val longPassword = Range(0, 20).map(_ => password).mkString("")
-        longPassword.boundedBcryptSafe.isFailure should be(true)
+        longPassword.bcryptSafeBounded.isFailure should be(true)
       }
 
       "encrypt with provided salt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
         val salt = BCrypt.gensalt()
         val password = "password"
-        val hash = password.boundedBcryptSafe(salt)
+        val hash = password.bcryptSafeBounded(salt)
         hash.isSuccess shouldEqual true
         val extractedHash = hash.get
-        password.isBoundedBcryptedSafe(extractedHash) shouldEqual Success(true)
-        "my new password".isBoundedBcryptedSafe(extractedHash) shouldEqual Success(false)
+        password.isBcryptedSafeBounded(extractedHash) shouldEqual Success(true)
+        "my new password".isBcryptedSafeBounded(extractedHash) shouldEqual Success(false)
         val longPassword = Range(0, 20).map(_ => password).mkString("")
-        longPassword.boundedBcryptSafe(salt).isFailure should be(true)
+        longPassword.bcryptSafeBounded(salt).isFailure should be(true)
       }
 
       "encrypt with provided rounds, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
         val password = "password"
-        val hash = password.boundedBcryptSafe(10)
+        val hash = password.bcryptSafeBounded(10)
         hash.isSuccess shouldEqual true
         val extractedHash = hash.get
-        password.isBoundedBcryptedSafe(extractedHash) shouldEqual Success(true)
-        "my new password".isBoundedBcryptedSafe(extractedHash) shouldEqual Success(false)
+        password.isBcryptedSafeBounded(extractedHash) shouldEqual Success(true)
+        "my new password".isBcryptedSafeBounded(extractedHash) shouldEqual Success(false)
         val longPassword = Range(0, 20).map(_ => password).mkString("")
-        longPassword.boundedBcryptSafe(10).isFailure should be(true)
+        longPassword.bcryptSafeBounded(10).isFailure should be(true)
       }
 
       "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
         val password = "password"
-        val result = password.isBoundedBcryptedSafe(password)
+        val result = password.isBcryptedSafeBounded(password)
         val longPassword = Range(0, 20).map(_ => password).mkString("")
         result.isFailure shouldEqual true
-        longPassword.isBoundedBcryptedSafe(password).isFailure shouldEqual true
+        longPassword.isBcryptedSafeBounded(password).isFailure shouldEqual true
       }
 
       "attempting to use rounds > 30 will result in a scala.util.Failure" in {
-        val result = "password".boundedBcryptSafe(31)
+        val result = "password".bcryptSafeBounded(31)
         result.isFailure shouldEqual true
       }
 
       "attempting to use an invalid salt will result in a scala.util.Failure" in {
-        val result = "password".boundedBcryptSafe("invalid-salt")
+        val result = "password".bcryptSafeBounded("invalid-salt")
         result.isFailure shouldEqual true
       }
     }
@@ -98,21 +98,21 @@ class bcryptSpec extends WordSpec with Matchers {
       "encrypt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
         val password = "my password"
         val hash = password.boundedBcrypt
-        password.isBoundedBcrypted(hash) shouldEqual true
-        "my new password".isBoundedBcrypted(hash) shouldEqual false
+        password.isBcryptedBounded(hash) shouldEqual true
+        "my new password".isBcryptedBounded(hash) shouldEqual false
         val longPassword = Range(0, 20).map(_ => password).mkString("")
         val cought = intercept[IllegalArgumentException](longPassword.boundedBcrypt)
         cought.getMessage should be(s"$longPassword was more than 71 bytes long.")
-        val cought2 = intercept[IllegalArgumentException](longPassword.isBoundedBcrypted(hash))
+        val cought2 = intercept[IllegalArgumentException](longPassword.isBcryptedBounded(hash))
         cought2.getMessage should be(s"$longPassword was more than 71 bytes long.")
       }
 
       "encrypt with provided salt and check if bcrypted" in {
         val salt = BCrypt.gensalt()
         val password = "password"
-        val hash = password.boundedBcrypt(salt)
-        password.isBoundedBcrypted(hash) shouldEqual true
-        "my new password".isBoundedBcrypted(hash) shouldEqual false
+        val hash = password.bcryptBounded(salt)
+        password.isBcryptedBounded(hash) shouldEqual true
+        "my new password".isBcryptedBounded(hash) shouldEqual false
         val longPassword = Range(0, 20).map(_ => password).mkString("")
         val cought = intercept[IllegalArgumentException](longPassword.boundedBcrypt)
         cought.getMessage should be(s"$longPassword was more than 71 bytes long.")
@@ -120,17 +120,17 @@ class bcryptSpec extends WordSpec with Matchers {
 
       "encrypt with provided rounds and check if bcrypted" in {
         val password = "password"
-        val hash = password.boundedBcrypt(10)
-        password.isBoundedBcrypted(hash) shouldEqual true
-        "my new password".isBoundedBcrypted(hash) shouldEqual false
+        val hash = password.bcryptBounded(10)
+        password.isBcryptedBounded(hash) shouldEqual true
+        "my new password".isBcryptedBounded(hash) shouldEqual false
         val longPassword = Range(0, 20).map(_ => password).mkString("")
-        val cought = intercept[IllegalArgumentException](longPassword.boundedBcrypt(10))
+        val cought = intercept[IllegalArgumentException](longPassword.bcryptBounded(10))
         cought.getMessage should be(s"$longPassword was more than 71 bytes long.")
       }
 
       "throw an exception if bcrypt parameters are incorrect" in {
         val invalidSalt = "bad-salt"
-        val caught = intercept[IllegalArgumentException]("password".boundedBcrypt(invalidSalt))
+        val caught = intercept[IllegalArgumentException]("password".bcryptBounded(invalidSalt))
         caught.getMessage shouldEqual "Invalid salt version"
       }
     }

--- a/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
+++ b/src/test/scala/com/github/t3hnar/bcrypt/bcryptSpec.scala
@@ -6,57 +6,128 @@ import scala.util.Success
 
 class bcryptSpec extends WordSpec with Matchers {
   "safe APIs" should {
-    "encrypt and check if bcrypted" in {
-      val hash = "my password".bcrypt
-      "my password".isBcryptedSafe(hash) shouldEqual Success(true)
-      "my new password".isBcryptedSafe(hash) shouldEqual Success(false)
+    "bounded APIs" should {
+      "encrypt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
+        val password = "my password"
+        val hash = password.boundedBcrypt
+        password.isBoundedBcryptedSafe(hash) shouldEqual Success(true)
+        "my new password".isBoundedBcryptedSafe(hash) shouldEqual Success(false)
+        val longHash = Range(0, 20).map(_ => password).mkString("")
+        longHash.safeBoundedBcrypt.isFailure should be(true)
+      }
+
+      "encrypt with provided salt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
+        val salt = BCrypt.gensalt()
+        val password = "password"
+        val hash = password.boundedBcryptSafe(salt)
+        hash.isSuccess shouldEqual true
+        val extractedHash = hash.get
+        password.isBoundedBcryptedSafe(extractedHash) shouldEqual Success(true)
+        "my new password".isBoundedBcryptedSafe(extractedHash) shouldEqual Success(false)
+        val longHash = Range(0, 20).map(_ => password).mkString("")
+        longHash.safeBoundedBcrypt.isFailure should be(true)
+      }
+
+      "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
+        val result = "password".isBoundedBcryptedSafe("password")
+        result.isFailure shouldEqual true
+      }
+
+      "attempting to use rounds > 30 will result in a scala.util.Failure" in {
+        val result = "password".boundedBcryptSafe(31)
+        result.isFailure shouldEqual true
+      }
+
+      "attempting to use an invalid salt will result in a scala.util.Failure" in {
+        val result = "password".boundedBcryptSafe("invalid-salt")
+        result.isFailure shouldEqual true
+      }
     }
 
-    "encrypt with provided salt and check if bcrypted" in {
-      val salt = BCrypt.gensalt()
-      val hash = "password".bcryptSafe(salt)
-      hash.isSuccess shouldEqual true
-      val extractedHash = hash.get
-      "password".isBcryptedSafe(extractedHash) shouldEqual Success(true)
-      "my new password".isBcryptedSafe(extractedHash) shouldEqual Success(false)
-    }
+    "unbounded APIs" should {
+      "encrypt and check if bcrypted" in {
+        val hash = "my password".bcrypt
+        "my password".isBcryptedSafe(hash) shouldEqual Success(true)
+        "my new password".isBcryptedSafe(hash) shouldEqual Success(false)
+      }
 
-    "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
-      val result = "password".isBcryptedSafe("password")
-      result.isFailure shouldEqual true
-    }
+      "encrypt with provided salt and check if bcrypted" in {
+        val salt = BCrypt.gensalt()
+        val hash = "password".bcryptSafe(salt)
+        hash.isSuccess shouldEqual true
+        val extractedHash = hash.get
+        "password".isBcryptedSafe(extractedHash) shouldEqual Success(true)
+        "my new password".isBcryptedSafe(extractedHash) shouldEqual Success(false)
+      }
 
-    "attempting to use rounds > 30 will result in a scala.util.Failure" in {
-      val result = "password".bcryptSafe(31)
-      result.isFailure shouldEqual true
-    }
+      "attempting to check isBcrypted against a non-bcrypted string will result in a scala.util.Failure" in {
+        val result = "password".isBcryptedSafe("password")
+        result.isFailure shouldEqual true
+      }
 
-    "attempting to use an invalid salt will result in a scala.util.Failure" in {
-      val result = "password".bcryptSafe("invalid-salt")
-      result.isFailure shouldEqual true
+      "attempting to use rounds > 30 will result in a scala.util.Failure" in {
+        val result = "password".bcryptSafe(31)
+        result.isFailure shouldEqual true
+      }
+
+      "attempting to use an invalid salt will result in a scala.util.Failure" in {
+        val result = "password".bcryptSafe("invalid-salt")
+        result.isFailure shouldEqual true
+      }
     }
   }
 
   "unsafe APIs" should {
-    "encrypt and check if bcrypted" in {
-      val hash = "my password".bcrypt
-      "my password".isBcrypted(hash) shouldEqual true
-      "my new password".isBcrypted(hash) shouldEqual false
-    }
-
-    "encrypt with provided salt and check if bcrypted" in {
-      val salt = BCrypt.gensalt()
-      val hash = "password".bcrypt(salt)
-      "password".isBcrypted(hash) shouldEqual true
-      "my new password".isBcrypted(hash) shouldEqual false
-    }
-
-    "throw an exception if bcrypt parameters are incorrect" in {
-      val invalidSalt = "bad-salt"
-      val caught = intercept[IllegalArgumentException] {
-        "password".bcrypt(invalidSalt)
+    "bounded APIs" should {
+      "encrypt, check if bcrypted and fail if bounds are greater than 71 bytes long" in {
+        val password = "my password"
+        val hash = password.boundedBcrypt
+        password.isBoundedBcrypted(hash) shouldEqual true
+        "my new password".isBoundedBcrypted(hash) shouldEqual false
+        val longHash = Range(0, 20).map(_ => password).mkString("")
+        val cought = intercept[IllegalArgumentException](longHash.boundedBcrypt)
+        cought.getMessage should be(s"$longHash was more than 71 bytes long.")
       }
-      caught.getMessage shouldEqual "Invalid salt version"
+
+      "encrypt with provided salt and check if bcrypted" in {
+        val salt = BCrypt.gensalt()
+        val password = "password"
+        val hash = password.boundedBcrypt(salt)
+        password.isBoundedBcrypted(hash) shouldEqual true
+        "my new password".isBoundedBcrypted(hash) shouldEqual false
+        val longHash = Range(0, 20).map(_ => password).mkString("")
+        val cought = intercept[IllegalArgumentException](longHash.boundedBcrypt)
+        cought.getMessage should be(s"$longHash was more than 71 bytes long.")
+      }
+
+      "throw an exception if bcrypt parameters are incorrect" in {
+        val invalidSalt = "bad-salt"
+        val caught = intercept[IllegalArgumentException]("password".boundedBcrypt(invalidSalt))
+        caught.getMessage shouldEqual "Invalid salt version"
+      }
+    }
+
+    "unbounded APIs" should {
+      "encrypt and check if bcrypted" in {
+        val hash = "my password".bcrypt
+        "my password".isBcrypted(hash) shouldEqual true
+        "my new password".isBcrypted(hash) shouldEqual false
+      }
+
+      "encrypt with provided salt and check if bcrypted" in {
+        val salt = BCrypt.gensalt()
+        val hash = "password".bcrypt(salt)
+        "password".isBcrypted(hash) shouldEqual true
+        "my new password".isBcrypted(hash) shouldEqual false
+      }
+
+      "throw an exception if bcrypt parameters are incorrect" in {
+        val invalidSalt = "bad-salt"
+        val caught = intercept[IllegalArgumentException] {
+          "password".bcrypt(invalidSalt)
+        }
+        caught.getMessage shouldEqual "Invalid salt version"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR references [this issue](https://github.com/t3hnar/scala-bcrypt/issues/23). I left a comment about better possible implementations but I wanted your approval first (like another package for prettier method names). 

I left another comment up for consideration, as it creates possible confusion. The `bcrypt` method looks like it does only one round, when it actually does 10. Maybe update the documentation to explain this, or explicitly do one round.